### PR TITLE
Fix cargo build --release in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://docs.substrate.io/install/
 Build the trappist repository with 
 ```
 git clone -b xcm-demo --depth 1 https://github.com/paritytech/trappist
-cd trappist && cargo build –-release
+cd trappist && cargo build --release
 ```
 
 Leave in the `target/release` folder:


### PR DESCRIPTION
Wrong dash symbol breaks command.

```
trappist % cargo build –-release
error: Found argument '–-release' which wasn't expected, or isn't valid in this context

USAGE:
    cargo build [OPTIONS]

For more information try --help
```

**– vs -**